### PR TITLE
Create the output directory if it does not already exist.

### DIFF
--- a/src/main/java/org/springdoc/maven/plugin/SpringDocMojo.java
+++ b/src/main/java/org/springdoc/maven/plugin/SpringDocMojo.java
@@ -44,6 +44,7 @@ public class SpringDocMojo extends AbstractMojo {
 			String result = null;
 			if (responseCode == HttpURLConnection.HTTP_OK) {
 				result = this.readFullyAsString(conection.getInputStream());
+				outputDir.mkdirs();
 				Files.write(Paths.get(outputDir.getAbsolutePath() + "/" + outputFileName), result.getBytes());
 			} else {
 				getLog().error("An error has occured: Response code " + responseCode);


### PR DESCRIPTION
This would typically happen elsewhere in the maven lifecyle in most cases, but if a different directory is used, or if there is nothing to compile, the target directory may not be created.

This fixes #3 .