### PR TITLE
Add skip parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ It possible to customise the following plugin properties:
     * The default value is: ${project.build.directory}
 *   outputFileName: The file name that contains the OpenAPI description.  
     * The default value is: openapi.json
+*   skip: Skip execution if set to true.
+    * The default value is: false
 
 ```xml
 <plugin>
@@ -77,6 +79,7 @@ It possible to customise the following plugin properties:
   <apiDocsUrl>http://localhost:8080/v3/api-docs</apiDocsUrl>
   <outputFileName>openapi.json</outputFileName>
   <outputDir>/home/springdoc/maven-output</outputDir>
+  <skip>false</skip>
  </configuration>
 </plugin>
 ```

--- a/src/main/java/org/springdoc/maven/plugin/SpringDocMojo.java
+++ b/src/main/java/org/springdoc/maven/plugin/SpringDocMojo.java
@@ -46,12 +46,22 @@ public class SpringDocMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${project}", readonly = true)
 	private MavenProject project;
 
+	/**
+	 * Skip execution if set to true. Default is false.
+	 */
+	@Parameter(defaultValue = "false", property = "skip")
+	private boolean skip;
+
 	@Component
 	private MavenProjectHelper projectHelper;
 
 	private static final String GET = "GET";
 
 	public void execute() {
+		if (skip) {
+			getLog().info("Skip execution as per configuration");
+			return;
+		}
 		try {
 			URL urlForGetRequest = new URL(apiDocsUrl);
 			HttpURLConnection conection = (HttpURLConnection) urlForGetRequest.openConnection();


### PR DESCRIPTION
Hi!

I use this plugin but in some scenarios I disable integration tests using the skip flag from springboot-maven-plugin. in this scenario the springdoc plugin logs an error because it obvsiously cannot access the application. 

Here is a PR adding a parameter allowing to skip the plugin execution.