### PR TITLE
Add parameter that makes it possible to attach openapi.yaml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,59 +9,65 @@ The plugin works in conjunction with spring-boot-maven plugin.
 
 You can test it during the integration tests phase using the maven command:
 
-```properties
+```shell
 mvn verify
 ```
 
 In order to use this functionality, you need to add the plugin declaration on the plugins section of your pom.xml:
 
 ```xml
-<plugin>
- <groupId>org.springframework.boot</groupId>
- <artifactId>spring-boot-maven-plugin</artifactId>
- <version>2.3.4.RELEASE</version>
- <configuration>
-    <jvmArguments>-Dspring.application.admin.enabled=true</jvmArguments>
- </configuration>
- <executions>
-  <execution>
-   <id>pre-integration-test</id>
-   <goals>
-    <goal>start</goal>
-   </goals>
-  </execution>
-  <execution>
-   <id>post-integration-test</id>
-   <goals>
-    <goal>stop</goal>
-   </goals>
-  </execution>
- </executions>
-</plugin>
-<plugin>
- <groupId>org.springdoc</groupId>
- <artifactId>springdoc-openapi-maven-plugin</artifactId>
- <version>1.1</version>
- <executions>
-  <execution>
-   <id>integration-test</id>
-   <goals>
-    <goal>generate</goal>
-   </goals>
-  </execution>
- </executions>
-</plugin>
+<plugins>
+  <plugin>
+   <groupId>org.springframework.boot</groupId>
+   <artifactId>spring-boot-maven-plugin</artifactId>
+   <version>2.3.4.RELEASE</version>
+   <configuration>
+      <jvmArguments>-Dspring.application.admin.enabled=true</jvmArguments>
+   </configuration>
+   <executions>
+    <execution>
+     <id>pre-integration-test</id>
+     <goals>
+      <goal>start</goal>
+     </goals>
+    </execution>
+    <execution>
+     <id>post-integration-test</id>
+     <goals>
+      <goal>stop</goal>
+     </goals>
+    </execution>
+   </executions>
+  </plugin>
+  <plugin>
+   <groupId>org.springdoc</groupId>
+   <artifactId>springdoc-openapi-maven-plugin</artifactId>
+   <version>1.1</version>
+   <executions>
+    <execution>
+     <id>integration-test</id>
+     <goals>
+      <goal>generate</goal>
+     </goals>
+    </execution>
+   </executions>
+  </plugin>
+</plugins>
 ```
 			
 ## **Custom settings of the springdoc-openapi-maven-plugin**
 
 It possible to customise the following plugin properties:
+*   attachArtifact: install / deploy the api doc to the repository
+    * The default value is: false
 *   apiDocsUrl: The local url of your (json or yaml). 
     * The default value is: http://localhost:8080/v3/api-docs
 *  outputDir: The output directory, where to generate the OpenAPI description.
     * The default value is: ${project.build.directory}
 *   outputFileName: The file name that contains the OpenAPI description.  
     * The default value is: openapi.json
+*   outputFileType: file type of the api doc (json or yaml)
+    * The default value is: json
 *   skip: Skip execution if set to true.
     * The default value is: false
 

--- a/src/main/java/org/springdoc/maven/plugin/SpringDocMojo.java
+++ b/src/main/java/org/springdoc/maven/plugin/SpringDocMojo.java
@@ -26,23 +26,35 @@ import org.apache.maven.project.MavenProjectHelper;
 @Mojo(name = "generate", requiresProject = true, defaultPhase = LifecyclePhase.INTEGRATION_TEST, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
 public class SpringDocMojo extends AbstractMojo {
 
-	@Parameter(defaultValue = "http://localhost:8080/v3/api-docs", property = "apiDocsUrl", required = true)
+	/**
+	 * The URL from where the api doc is retrieved.
+	 */
+	@Parameter(defaultValue = "http://localhost:8080/v3/api-docs", property = "springdoc.apiDocsUrl", required = true)
 	private String apiDocsUrl;
 
-	@Parameter(defaultValue = "openapi.json", property = "outputFileName", required = true)
+	/**
+	 * File name of the generated api doc.
+	 */
+	@Parameter(defaultValue = "openapi.json", property = "springdoc.outputFileName", required = true)
 	private String outputFileName;
 
-	@Parameter(defaultValue = "${project.build.directory}", property = "outputDir", required = true)
+	/**
+	 * Output directory for the generated api doc.
+	 */
+	@Parameter(defaultValue = "${project.build.directory}", property = "springdoc.outputDir", required = true)
 	private File outputDir;
 
-	@Parameter(defaultValue = "json", property = "outputFileType" , required = true)
+	/**
+	 * Output file type of the generated api doc (yaml or json).
+	 */
+	@Parameter(defaultValue = "json", property = "springdoc.outputFileType" , required = true)
 	private String outputFileType;
 
 	/**
 	 * Attach generated documentation as artifact to the Maven project.
 	 * If true documentation will be deployed along with other artifacts.
 	 */
-	@Parameter(defaultValue = "false", property = "attachArtifact")
+	@Parameter(defaultValue = "false", property = "springdoc.attachArtifact")
 	private boolean attachArtifact;
 
 	@Parameter(defaultValue = "${project}", readonly = true)

--- a/src/main/java/org/springdoc/maven/plugin/SpringDocMojo.java
+++ b/src/main/java/org/springdoc/maven/plugin/SpringDocMojo.java
@@ -63,7 +63,7 @@ public class SpringDocMojo extends AbstractMojo {
 	/**
 	 * Skip execution if set to true. Default is false.
 	 */
-	@Parameter(defaultValue = "false", property = "skip")
+	@Parameter(defaultValue = "false", property = "springdoc.skip")
 	private boolean skip;
 
 	@Component

--- a/src/main/java/org/springdoc/maven/plugin/SpringDocMojo.java
+++ b/src/main/java/org/springdoc/maven/plugin/SpringDocMojo.java
@@ -20,10 +20,9 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
 
 /**
- * Goal which touches a timestamp file.
+ * Generate a openapi specification file.
  *
  */
-
 @Mojo(name = "generate", requiresProject = true, defaultPhase = LifecyclePhase.INTEGRATION_TEST, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
 public class SpringDocMojo extends AbstractMojo {
 
@@ -35,6 +34,9 @@ public class SpringDocMojo extends AbstractMojo {
 
 	@Parameter(defaultValue = "${project.build.directory}", property = "outputDir", required = true)
 	private File outputDir;
+
+	@Parameter(defaultValue = "json", property = "outputFileType" , required = true)
+	private String outputFileType;
 
 	/**
 	 * Attach generated documentation as artifact to the Maven project.
@@ -67,9 +69,8 @@ public class SpringDocMojo extends AbstractMojo {
 			HttpURLConnection conection = (HttpURLConnection) urlForGetRequest.openConnection();
 			conection.setRequestMethod(GET);
 			int responseCode = conection.getResponseCode();
-			String result = null;
 			if (responseCode == HttpURLConnection.HTTP_OK) {
-				result = this.readFullyAsString(conection.getInputStream());
+				String result = this.readFullyAsString(conection.getInputStream());
 				outputDir.mkdirs();
 				Files.write(Paths.get(outputDir.getAbsolutePath() + "/" + outputFileName), result.getBytes(StandardCharsets.UTF_8));
 				if (attachArtifact) addArtifactToMaven();
@@ -89,7 +90,7 @@ public class SpringDocMojo extends AbstractMojo {
 	private ByteArrayOutputStream readFully(InputStream inputStream) throws IOException {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		byte[] buffer = new byte[1024];
-		int length = 0;
+		int length;
 		while ((length = inputStream.read(buffer)) != -1) {
 			baos.write(buffer, 0, length);
 		}
@@ -98,6 +99,6 @@ public class SpringDocMojo extends AbstractMojo {
 
 	private void addArtifactToMaven() {
 		File swaggerFile = new File(outputDir.getAbsolutePath() + '/' + outputFileName);
-		projectHelper.attachArtifact(project, "json", "openapi", swaggerFile);
+		projectHelper.attachArtifact(project, outputFileType, "openapi", swaggerFile);
 	}
 }


### PR DESCRIPTION
This PR also improves the java doc comments (They are displayed on `mvn springdoc-openapi:help -Ddetail=true`)