### PR TITLE
Add JSON formatting #42

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ It possible to customise the following plugin properties:
     * The default value is: openapi.json
 *   skip: Skip execution if set to true.
     * The default value is: false
+*   format: Formats the json with indentation.
+    * The default value is: false
+    * Should be used with JSON only.
 *   headers: List of headers to send in request
     * The default value is empty
 
@@ -89,6 +92,7 @@ It possible to customise the following plugin properties:
   <outputFileName>openapi.json</outputFileName>
   <outputDir>/home/springdoc/maven-output</outputDir>
   <skip>false</skip>
+  <format>true</format>
   <headers>
     <header1key>header1value</header1key>
     <header2key>header2value</header2key>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,12 @@
 			<version>3.6.4</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+			<version>20220320</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/springdoc/maven/plugin/SpringDocMojo.java
+++ b/src/main/java/org/springdoc/maven/plugin/SpringDocMojo.java
@@ -123,7 +123,7 @@ public class SpringDocMojo extends AbstractMojo {
 
 
 	/**
-	 * Read fully as string string.
+	 * Read fully as string.
 	 *
 	 * @param inputStream the input stream
 	 * @return the string

--- a/src/main/java/org/springdoc/maven/plugin/SpringDocMojo.java
+++ b/src/main/java/org/springdoc/maven/plugin/SpringDocMojo.java
@@ -19,6 +19,8 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
+import org.json.JSONObject;
+import org.json.JSONTokener;
 
 /**
  * Generate a openapi specification file.
@@ -116,6 +118,12 @@ public class SpringDocMojo extends AbstractMojo {
 			int responseCode = connection.getResponseCode();
 			if (responseCode == HttpURLConnection.HTTP_OK) {
 				String result = this.readFullyAsString(connection.getInputStream());
+
+				if (format) {
+					JSONObject object = new JSONObject(new JSONTokener(result));
+					result = object.toString(2);
+				}
+
 				outputDir.mkdirs();
 				Files.write(Paths.get(outputDir.getAbsolutePath() + "/" + outputFileName), result.getBytes(StandardCharsets.UTF_8));
 				if (attachArtifact) addArtifactToMaven();

--- a/src/main/java/org/springdoc/maven/plugin/SpringDocMojo.java
+++ b/src/main/java/org/springdoc/maven/plugin/SpringDocMojo.java
@@ -119,7 +119,7 @@ public class SpringDocMojo extends AbstractMojo {
 			if (responseCode == HttpURLConnection.HTTP_OK) {
 				String result = this.readFullyAsString(connection.getInputStream());
 
-				if (format) {
+				if (format && outputFileName.endsWith(DEFAULT_OUTPUT_EXTENSION)) {
 					JSONObject object = new JSONObject(new JSONTokener(result));
 					result = object.toString(2);
 				}

--- a/src/main/java/org/springdoc/maven/plugin/SpringDocMojo.java
+++ b/src/main/java/org/springdoc/maven/plugin/SpringDocMojo.java
@@ -81,6 +81,12 @@ public class SpringDocMojo extends AbstractMojo {
 	private boolean skip;
 
 	/**
+	 * Formats the openapi.json file if set to true. Default is false.
+	 */
+	@Parameter(defaultValue = "false", property = "springdoc.format")
+	private boolean format;
+
+	/**
 	 * Headers to send in request
 	 */
 	@Parameter(property = "headers")


### PR DESCRIPTION
I took the liberty of adding the PR for the issue.
 It adds a lightweight dependency of `org.json`. Used to parse the string in case we want to write to a `.json` file and then indent it properly.

Please do share your thoughts.

Related to: https://github.com/springdoc/springdoc-openapi-maven-plugin/issues/42