### PR TITLE
Adjustments to allow multiple parallel fetches from the api

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 
 ## **Introduction to springdoc-openapi-maven-plugin**
 
-The aim of springdoc-openapi-maven-plugin is to generate json and yaml OpenAPI description during runtime. If you want to get swagger definitions properly, the application should completely running as locally.
-The plugin works during integration-tests phase, and generate the OpenAPI description. 
-The plugin works in conjunction with spring-boot-maven plugin. 
+The aim of springdoc-openapi-maven-plugin is to generate json and yaml OpenAPI description during runtime. If you want
+to get swagger definitions properly, the application should completely running as locally.
+The plugin works during integration-tests phase, and generate the OpenAPI description.
+The plugin works in conjunction with spring-boot-maven plugin.
 
 You can test it during the integration tests phase using the maven command:
 
@@ -16,62 +17,69 @@ mvn verify
 In order to use this functionality, you need to add the plugin declaration on the plugins section of your pom.xml:
 
 ```xml
+
 <plugins>
-  <plugin>
-   <groupId>org.springframework.boot</groupId>
-   <artifactId>spring-boot-maven-plugin</artifactId>
-   <version>2.3.4.RELEASE</version>
-   <configuration>
-      <jvmArguments>-Dspring.application.admin.enabled=true</jvmArguments>
-   </configuration>
-   <executions>
-    <execution>
-     <id>pre-integration-test</id>
-     <goals>
-      <goal>start</goal>
-     </goals>
-    </execution>
-    <execution>
-     <id>post-integration-test</id>
-     <goals>
-      <goal>stop</goal>
-     </goals>
-    </execution>
-   </executions>
-  </plugin>
-  <plugin>
-   <groupId>org.springdoc</groupId>
-   <artifactId>springdoc-openapi-maven-plugin</artifactId>
-   <version>1.1</version>
-   <executions>
-    <execution>
-     <id>integration-test</id>
-     <goals>
-      <goal>generate</goal>
-     </goals>
-    </execution>
-   </executions>
-  </plugin>
+    <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>2.3.4.RELEASE</version>
+        <configuration>
+            <jvmArguments>-Dspring.application.admin.enabled=true</jvmArguments>
+        </configuration>
+        <executions>
+            <execution>
+                <id>pre-integration-test</id>
+                <goals>
+                    <goal>start</goal>
+                </goals>
+            </execution>
+            <execution>
+                <id>post-integration-test</id>
+                <goals>
+                    <goal>stop</goal>
+                </goals>
+            </execution>
+        </executions>
+    </plugin>
+    <plugin>
+        <groupId>org.springdoc</groupId>
+        <artifactId>springdoc-openapi-maven-plugin</artifactId>
+        <version>1.1</version>
+        <executions>
+            <execution>
+                <id>integration-test</id>
+                <goals>
+                    <goal>generate</goal>
+                </goals>
+            </execution>
+        </executions>
+    </plugin>
 </plugins>
 ```
-			
+
+The provided spring-boot-maven-plugin configuration will start an application context, which in terms allows us to get the api documentation that is only generated on startup.
+
+If you are wondering how you could make this independent (not relying on local database for startup, or issues with the port), please have a look at [The Tip Section](#tip)
+
 ## **Custom settings of the springdoc-openapi-maven-plugin**
 
 It possible to customise the following plugin properties:
-*   attachArtifact: install / deploy the api doc to the repository
+
+* attachArtifact: install / deploy the api doc to the repository
     * The default value is: false
-*   apiDocsUrl: The local url of your (json or yaml). 
+* apiDocsUrl: The local url of your (json or yaml).
     * The default value is: http://localhost:8080/v3/api-docs
-*  outputDir: The output directory, where to generate the OpenAPI description.
+* outputDir: The output directory, where to generate the OpenAPI description.
     * The default value is: ${project.build.directory}
-*   outputFileName: The file name that contains the OpenAPI description.  
+* outputFileName: The file name that contains the OpenAPI description.
     * The default value is: openapi.json
-*   skip: Skip execution if set to true.
+* skip: Skip execution if set to true.
     * The default value is: false
-*   headers: List of headers to send in request
+* headers: List of headers to send in request
     * The default value is empty
 
 ```xml
+
 <plugin>
     <groupId>org.springdoc</groupId>
     <artifactId>springdoc-openapi-maven-plugin</artifactId>
@@ -105,6 +113,45 @@ It possible to customise the following plugin properties:
     </configuration>
 </plugin>
 ```
+
+## **Tip**
+
+To make the build process a little more independent, you can adjust the spring-boot-maven-plugin. To do so, you can
+change the configuration to this:
+
+```xml
+<plugin>
+  <groupId>org.springframework.boot</groupId>
+  <artifactId>spring-boot-maven-plugin</artifactId>
+  <configuration>
+    <jvmArguments>-Dspring.application.admin.enabled=true</jvmArguments>
+    <environmentVariables>
+        <SPRING_PROFILES_ACTIVE>integration</SPRING_PROFILES_ACTIVE>
+    </environmentVariables>
+  </configuration>
+  
+  ...
+</plugin>
+```
+
+This will set the active spring profile, "integration", which on the other hand allows you to add a custom application.properties file, called `application-integration.properties`.
+
+This file might look like this:
+
+```properties
+server.port=8090
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=password
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+```
+
+By doing so, you can configure the application context, that is started in the integration-test phase.
+
+This allows you to change the port, making the build independent of the fact that you might have another application instance running
+
+If you add (like in this example) a h2 database, you can make the build completely independent, allowing the application to start without any precondition. At the end of the day, we are only interested in the api that is generated at the startup phase.
 
 # **Thank you for the support**
 

--- a/README.md
+++ b/README.md
@@ -73,27 +73,36 @@ It possible to customise the following plugin properties:
 
 ```xml
 <plugin>
- <groupId>org.springdoc</groupId>
- <artifactId>springdoc-openapi-maven-plugin</artifactId>
- <version>1.1</version>
- <executions>
-  <execution>
-   <id>integration-test</id>
-   <goals>
-    <goal>generate</goal>
-   </goals>
-  </execution>
- </executions>
- <configuration>
-  <apiDocsUrl>http://localhost:8080/v3/api-docs</apiDocsUrl>
-  <outputFileName>openapi.json</outputFileName>
-  <outputDir>/home/springdoc/maven-output</outputDir>
-  <skip>false</skip>
-  <headers>
-    <header1key>header1value</header1key>
-    <header2key>header2value</header2key>
-  </headers>
- </configuration>
+    <groupId>org.springdoc</groupId>
+    <artifactId>springdoc-openapi-maven-plugin</artifactId>
+    <version>2.0</version>
+    <executions>
+        <execution>
+            <id>integration-test</id>
+            <goals>
+                <goal>generate</goal>
+            </goals>
+        </execution>
+    </executions>
+    <configuration>
+        <baseUrl>http://localhost:8080</baseUrl>
+        <exports>
+            <export>
+                <path>v3/api-docs</path>
+                <outputFileName>openapi.json</outputFileName>
+            </export>
+            <export>
+                <path>v3/api-docs.yaml</path>
+                <outputFileName>openapi.yaml</outputFileName>
+            </export>
+        </exports>
+        <outputDir>/home/springdoc/maven-output</outputDir>
+        <skip>false</skip>
+        <headers>
+            <header1key>header1value</header1key>
+            <header2key>header2value</header2key>
+        </headers>
+    </configuration>
 </plugin>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springdoc</groupId>
 	<artifactId>springdoc-openapi-maven-plugin</artifactId>
-	<version>1.5-SNAPSHOT</version>
+	<version>1.6</version>
 	<packaging>maven-plugin</packaging>
 	<name>springdoc-openapi-maven-plugin</name>
 	<description>springdoc OpenAPI 3 maven plugin</description>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springdoc</groupId>
 	<artifactId>springdoc-openapi-maven-plugin</artifactId>
-	<version>1.6</version>
+	<version>2.0</version>
 	<packaging>maven-plugin</packaging>
 	<name>springdoc-openapi-maven-plugin</name>
 	<description>springdoc OpenAPI 3 maven plugin</description>

--- a/src/main/java/org/springdoc/maven/plugin/ExportTarget.java
+++ b/src/main/java/org/springdoc/maven/plugin/ExportTarget.java
@@ -6,14 +6,25 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
 
+/**
+ * One export target is one entry that should be taken from the
+ * openapi documentation.
+ * <p>
+ * Any amount of export targets can be defined. They provide a
+ * simple {@link #path}, which should be fetched from and a {@link #outputFileName}
+ * which the results of the url should be written to.
+ */
 public class ExportTarget {
 
 	/**
 	 * The url to fetch from.
 	 */
-	@Parameter(property = "url", required = true)
-	private String url;
+	@Parameter(property = "path", required = true)
+	private String path;
 
 	/**
 	 * File name of the generated api doc.
@@ -21,31 +32,108 @@ public class ExportTarget {
 	@Parameter(property = "outputFileName", required = true)
 	private String outputFileName;
 
-	public static ExportTarget build(String url, String outputFileName) {
+	/**
+	 * Creates a new ExportTarget.
+	 * <p>
+	 * This method bypasses the need to create two constructors,
+	 * whilst keeping its fields private, without requiring constructors
+	 *
+	 * @param path           the path, relative to the url provided in the {@link SpringDocMojo#baseUrl}
+	 * @param outputFileName the file, that should be created with the contents of the {@link #path}.
+	 *                       This will be relative to the folder {@link SpringDocMojo#outputDir}
+	 * @return a new ExportTarget
+	 */
+	public static ExportTarget build(String path, String outputFileName) {
 		ExportTarget exportTarget = new ExportTarget();
-		exportTarget.url = url;
+		exportTarget.path = path;
 		exportTarget.outputFileName = outputFileName;
 		return exportTarget;
 	}
 
-	public String getUrl() {
-		return url;
-	}
-
-	public String getOutputFileName() {
-		return outputFileName;
-	}
-
-	public HttpURLConnection openConnection() {
+	public static URL joinToUrl(String url, String... paths) {
 		try {
-			URL url = new URL(getUrl());
-			try {
-				return (HttpURLConnection) url.openConnection();
-			} catch (IOException e) {
-				throw new IllegalStateException("Connection to " + getUrl() + " could not be established.", e);
-			}
+			return new URL(joinToString(url, paths));
 		} catch (MalformedURLException e) {
-			throw new IllegalStateException("The provided url " + getUrl() + " is not a valid URL.", e);
+			throw new IllegalStateException("The provided url " + url + Arrays.toString(paths) + " is not a valid URL.", e);
 		}
+	}
+
+	/**
+	 * Joins the provided base and additions, separating entries using the "/"
+	 * char, making sure that no slashes are doubled.
+	 *
+	 * @param base      the base of the string
+	 * @param additions all additional paths
+	 * @return a joined string, with no double slashes
+	 */
+	public static String joinToString(String base, String... additions) {
+		StringBuilder result = new StringBuilder(base);
+		if (result.toString().endsWith("/")) {
+			result = new StringBuilder(result.substring(0, result.length() - 1));
+		}
+
+		for (String path : additions) {
+			String currentPath = path;
+			if (!currentPath.startsWith("/")) {
+				currentPath = "/" + currentPath;
+			}
+			if (currentPath.endsWith("/")) {
+				currentPath = currentPath.substring(0, result.length() - 1);
+			}
+
+			result.append(currentPath);
+		}
+
+		return result.toString();
+	}
+
+	/**
+	 * Returns the set path
+	 *
+	 * @return the path
+	 */
+	public String getPath() {
+		return path;
+	}
+
+
+	/**
+	 * Opens a connection to the {@link #path}, relative to the provided
+	 * baseUrl.
+	 *
+	 * @param baseUrl the base url
+	 * @return an open HttpUrlConnection to the {@link #path}, relative to
+	 * the baseUrl
+	 */
+	public HttpURLConnection openConnection(String baseUrl) {
+		URL url = joinToUrl(baseUrl, path);
+		try {
+			return (HttpURLConnection) url.openConnection();
+		} catch (IOException e) {
+			throw new IllegalStateException("Connection to " + url + " could not be established.", e);
+		}
+	}
+
+	/**
+	 * This method creates a path to the {@link #outputFileName}, relative to
+	 * the provided baseDir.
+	 * <p>
+	 * If the parent does not exist, it will be created, assuming that the
+	 * created path will be filled later.
+	 * <p>
+	 * If the  {@link #outputFileName} is more complex than just a name (like
+	 * for example "documentation/generated/openapi.yml", this approach will
+	 * allow for any amount of sub folders.
+	 *
+	 * @param baseDir the base dir, under which the output file name should
+	 *                be created.
+	 * @return a Path to the output file
+	 */
+	public Path accessOutputFileFrom(String baseDir) {
+		String totalPath = joinToString(baseDir, outputFileName);
+		Path path = Paths.get(totalPath);
+
+		path.toFile().getParentFile().mkdirs();
+		return path;
 	}
 }

--- a/src/main/java/org/springdoc/maven/plugin/ExportTarget.java
+++ b/src/main/java/org/springdoc/maven/plugin/ExportTarget.java
@@ -1,0 +1,51 @@
+package org.springdoc.maven.plugin;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class ExportTarget {
+
+	/**
+	 * The url to fetch from.
+	 */
+	@Parameter(property = "url", required = true)
+	private String url;
+
+	/**
+	 * File name of the generated api doc.
+	 */
+	@Parameter(property = "outputFileName", required = true)
+	private String outputFileName;
+
+	public static ExportTarget build(String url, String outputFileName) {
+		ExportTarget exportTarget = new ExportTarget();
+		exportTarget.url = url;
+		exportTarget.outputFileName = outputFileName;
+		return exportTarget;
+	}
+
+	public String getUrl() {
+		return url;
+	}
+
+	public String getOutputFileName() {
+		return outputFileName;
+	}
+
+	public HttpURLConnection openConnection() {
+		try {
+			URL url = new URL(getUrl());
+			try {
+				return (HttpURLConnection) url.openConnection();
+			} catch (IOException e) {
+				throw new IllegalStateException("Connection to " + getUrl() + " could not be established.", e);
+			}
+		} catch (MalformedURLException e) {
+			throw new IllegalStateException("The provided url " + getUrl() + " is not a valid URL.", e);
+		}
+	}
+}

--- a/src/main/java/org/springdoc/maven/plugin/SpringDocMojo.java
+++ b/src/main/java/org/springdoc/maven/plugin/SpringDocMojo.java
@@ -35,10 +35,6 @@ public class SpringDocMojo extends AbstractMojo {
 	private static final String DEFAULT_OUTPUT_EXTENSION = ".json";
 
 	/**
-	 * The DEFAULT OUTPUT FILE.
-	 */
-	private static final String DEFAULT_OUTPUT_FILE = DEFAULT_OUTPUT_FILE_NAME + DEFAULT_OUTPUT_EXTENSION;
-	/**
 	 * The constant GET.
 	 */
 	private static final String GET = "GET";
@@ -83,6 +79,11 @@ public class SpringDocMojo extends AbstractMojo {
 	@Parameter(property = "exports", required = true)
 	private List<ExportTarget> exports;
 
+	/**
+	 * The base url, which all exports are relative to.
+	 * <p>
+	 * By default, it will be local host on port 8080, because this is the default value of spring.
+	 */
 	@Parameter(property = "baseUrl", defaultValue = "http://localhost:8080/", required = true)
 	private String baseUrl;
 


### PR DESCRIPTION
# Background

Whilst developing with this plugin, I tried to use it, to deploy the api through a gitlab pipeline. Since there are multiple different potential clients, the issue was, that I required both json and yaml, for different usecases. Additionally I wanted to deploy the generated ui as a static html website as well.

The issue is, that I could only choose one specific, lead to a lot of frustrations for the client developers.

This major change allows to do that.

# Removed Parameters

The following properties have been removed without deprecation:

-  apiDocsUrl 
- outputFileName

These two have been moved "exports".

# Added Parameters

- exports: a list of specific things to export from the api documentation
- baseUrl: The base url to the api documentation (for example http://localhost:8080), reducing the boilerplate in exports.

# Example usage:

```xml
<plugin>
    <groupId>org.springdoc</groupId>
    <artifactId>springdoc-openapi-maven-plugin</artifactId>
    <version>1.6</version>
    <executions>
        <execution>
            <phase>integration-test</phase>
            <goals>
                <goal>generate</goal>
            </goals>
        </execution>
    </executions>
    <configuration>
        <baseUrl>http://localhost:8090</baseUrl>
        <exports>
            <export>
                <path>v3/api-docs.yaml</path>
                <outputFileName>openapi.yaml</outputFileName>
            </export>
            <export>
                <path>v3/api-docs.yaml</path>
                <outputFileName>ui/api-docs.yaml</outputFileName>
            </export>
            <export>
                <path>v3/api-docs</path>
                <outputFileName>openapi.json</outputFileName>
            </export>
            <export>
                <path>swagger-ui/index.html</path>
                <outputFileName>ui/index.html</outputFileName>
            </export>
            <export>
                <path>swagger-ui/swagger-ui.css</path>
                <outputFileName>ui/swagger-ui.css</outputFileName>
            </export>
            <export>
                <path>swagger-ui/index.css</path>
                <outputFileName>ui/index.css</outputFileName>
            </export>
            <export>
                <path>swagger-ui/favicon-32x32.png</path>
                <outputFileName>ui/favicon-32x32.png</outputFileName>
            </export>
            <export>
                <path>swagger-ui/favicon-16x16.png</path>
                <outputFileName>ui/favicon-16x16.png</outputFileName>
            </export>
            <export>
                <path>swagger-ui/swagger-ui-bundle.js</path>
                <outputFileName>ui/swagger-ui-bundle.js</outputFileName>
            </export>
            <export>
                <path>swagger-ui/swagger-ui-standalone-preset.js</path>
                <outputFileName>ui/swagger-ui-standalone-preset.js</outputFileName>
            </export>
            <export>
                <path>swagger-ui/swagger-initializer.js</path>
                <outputFileName>ui/swagger-initializer.js</outputFileName>
            </export>
        </exports>
        <skip>false</skip>
    </configuration>
</plugin>
```

This example would fetch multiple parts from the swagger api.

# Risks

This is a breaking change. It is possible to make it not as breaking, but this would introduce a lot of complexity to maintain these legcy way.

# Open Points:

- Is the name "exports" okay? Naming is one of my weaknesses.
- Would more "ease of use" functions be a good idea?
- Any interactions I did not think about?
- Is this a good Idea in general, or is this going against the idea of this framework and would require another plugin?