### PR TITLE
Some missing links

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -7,7 +7,7 @@ something, or simply want to hack on the code this document should help you get 
 
 
 == Code of Conduct
-This project adheres to the Contributor Covenant link:CODE_OF_CONDUCT.adoc[code of
+This project adheres to the Contributor Covenant link:https://www.contributor-covenant.org/version/3/0/code_of_conduct/[code of
 conduct]. By participating, you are expected to uphold this code. 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 			<name>Badr NASS LAHSEN</name>
 			<email>support@springdoc.org</email>
 			<organization>springdoc</organization>
-			<organizationUrl>https://springdoc.github.io/springdoc-openapi/
+			<organizationUrl>https://springdoc.org/
 			</organizationUrl>
 		</developer>
 	</developers>


### PR DESCRIPTION
Link in `pom.xml` points to a GitHub page that nowadays is 404.

Also, the code of conduct is absent from the repository, so instead perhaps pointing it out to the mentioned Code Covenant CoC is useful.